### PR TITLE
 Fix all TBC backporting bugs and all Lua errors

### DIFF
--- a/ElvUI_CastBarOverlay/ElvUI_CastBarOverlay.toc
+++ b/ElvUI_CastBarOverlay/ElvUI_CastBarOverlay.toc
@@ -1,6 +1,6 @@
 ## Interface: 20400
 ## Author: Blazeflack
-## Version: 1.03
+## Version: 1.04
 ## Title: |cff00b30bE|r|cffC4C4C4lvUI|r |cff00b30bC|r|cffC4C4C4ast|cff00b30bB|r|cffC4C4C4ar|r |cff00b30bO|r|cffC4C4C4verlay|r
 ## Notes: Allows you to overlay castbars on other frames.
 ## RequiredDeps: ElvUI


### PR DESCRIPTION
* Backporting bug: It attempts to read the "arena" frames (numbered
  ElvUF_Arena1 to ElvUF_Arena5), which does not exist in TBC at all.
  This lead to a constant "nil" Lua error message whenever you load
  or switch ElvUI profile.

* There were a ton of (not backport-related) bugs where code attempted
  to read values that did not exist. Validation has now been added
  everywhere and logic has been rewritten to ensure that data tables
  exist before attempting to read fields from them. This stops all
  the remaining, constant Lua error messages that this addon was
  throwing.

These bugs all meant that whenever you switched profile or received another person's profile, you got tons of Lua errors and annoying interruptions. That's all fixed now!